### PR TITLE
Add options to phone verification

### DIFF
--- a/lib/authy/phone_verification.rb
+++ b/lib/authy/phone_verification.rb
@@ -6,6 +6,8 @@ module Authy
     #   :phone_number The persons phone number.
     #   :custom_code Pass along any generated custom code.
     #   :custom_message Custom Message.
+    #   :code_length Length of code to be sent(4-10).
+    #   :locale The language of the message received by user. 
     def self.start(params)
       params[:via] = "sms" unless %w(sms, call).include?(params[:via])
 

--- a/spec/authy/phone_verification_spec.rb
+++ b/spec/authy/phone_verification_spec.rb
@@ -16,6 +16,20 @@ describe "Authy::PhoneVerification" do
       expect(response.message).to eq "Text message sent to +1 111-111-1111."
     end
 
+    it "should send the code via SMS with code length" do
+      pending("API is not returning expected response in this case. The test phone number is invalid.")
+      response = Authy::PhoneVerification.start(
+        via: "sms",
+        country_code: "1",
+        phone_number: "111-111-1111",
+        code_length: "2387"
+      )
+
+      expect(response).to be_kind_of(Authy::Response)
+      expect(response).to be_ok
+      expect(response.message).to eq "Text message sent to +1 111-111-1111."
+    end
+
     # it "should send the code via CALL" do
     #   response = Authy::PhoneVerification.start(
     #     via: "call",

--- a/spec/authy/phone_verification_spec.rb
+++ b/spec/authy/phone_verification_spec.rb
@@ -20,13 +20,13 @@ describe "Authy::PhoneVerification" do
       response = Authy::PhoneVerification.start(
         via: "sms",
         country_code: "1",
-        phone_number: "2015550123",
+        phone_number: "201-555-0123",
         code_length: "4"
       )
 
       expect(response).to be_kind_of(Authy::Response)
       expect(response).to be_ok
-      expect(response.message).to eq "Text message sent to +1 2015550123."
+      expect(response.message).to eq "Text message sent to +1 201-555-0123."
     end
 
     # it "should send the code via CALL" do

--- a/spec/authy/phone_verification_spec.rb
+++ b/spec/authy/phone_verification_spec.rb
@@ -17,17 +17,16 @@ describe "Authy::PhoneVerification" do
     end
 
     it "should send the code via SMS with code length" do
-      pending("API is not returning expected response in this case. The test phone number is invalid.")
       response = Authy::PhoneVerification.start(
         via: "sms",
         country_code: "1",
-        phone_number: "111-111-1111",
-        code_length: "2387"
+        phone_number: "2015550123",
+        code_length: "4"
       )
 
       expect(response).to be_kind_of(Authy::Response)
       expect(response).to be_ok
-      expect(response.message).to eq "Text message sent to +1 111-111-1111."
+      expect(response.message).to eq "Text message sent to +1 2015550123."
     end
 
     # it "should send the code via CALL" do


### PR DESCRIPTION
**Add options**

_Now available options_
```
# options:
    #   :via (sms|call)
    #   :country_code Numeric calling country code of the country.
    #   :phone_number The persons phone number.
    #   :custom_code Pass along any generated custom code.
    #   :custom_message Custom Message.
    #   :code_length Length of code to be sent(4-10).
    #   :locale The language of the message received by user. 
```

_Checklist_
- [x] Add spec 

