### PR TITLE
Add check verification status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler --version '1.16.1'
 rvm:
   - 2.6
   - 2.5

--- a/README.md
+++ b/README.md
@@ -182,6 +182,28 @@ if response.ok?
 end
 ```
 
+### Check Verification Status using Verification UUID
+
+`Authy::PhoneVerification.status` takes an uuid from the original request.
+
+```ruby
+response = Authy::PhoneVerification.status(uuid: '550e8400-e29b-41d4-a716-446655440000')
+if response.ok?
+  # do something
+end
+```
+
+### Check Verification Status using Phone Number
+
+`Authy::PhoneVerification.status` takes a country code and a phone number.
+
+```ruby
+response = Authy::PhoneVerification.status(country_code: 1, phone_number: "111-111-1111")
+if response.ok?
+  # do something
+end
+```
+
 ## OneTouch Verification
 
 Another way to provide Two_factor authentication with Authy is by using OneTouch feature. 

--- a/lib/authy/phone_verification.rb
+++ b/lib/authy/phone_verification.rb
@@ -22,5 +22,12 @@ module Authy
       get_request("protected/json/phones/verification/check", params)
     end
 
+    # options:
+    #   :uuid The uuid from the original request.
+    #   :country_code Numeric calling country code of the country. (optional)
+    #   :phone_number The persons phone number. (optional)
+    def self.status(params)
+      get_request("protected/json/phones/verification/status", params)
+    end
   end
 end

--- a/spec/authy/phone_verification_spec.rb
+++ b/spec/authy/phone_verification_spec.rb
@@ -121,4 +121,27 @@ describe "Authy::PhoneVerification" do
     end
   end
 
+  describe 'Check Verification Status using Verification UUID' do
+    it "should return an error if uuid not found" do
+      response = Authy::PhoneVerification.status(
+        uuid: '550e8400-e29b-41d4-a716-446655440000'
+      )
+
+      expect(response).not_to be_ok
+      expect(response.message).to eq('Phone verification not found')
+    end
+  end
+
+  describe 'Check Verification Status using Phone Number' do
+  it "should return an error if phone_number not found" do
+      response = Authy::PhoneVerification.status(
+          country_code: '1',
+          phone_number: '201-555-0123'
+      )
+
+      expect(response).not_to be_ok
+      expect(response.message).to eq('Phone verification not found')
+    end
+  end
+
 end


### PR DESCRIPTION
Added check verification status method for [Check Verification Status request from Twilio Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-check-verification-status-using-verification-uuid&code-language=curl&code-sdk-version=default).

Simple usage:
- This example checks the status of the request using uuid:
```ruby
Authy::PhoneVerification.status(uuid: 'de0d6000-2d3b-0137-b327-12f5b40cad00')
> {"message"=>"Phone Verification status.", "status"=>"pending", "seconds_to_expire"=>513, "success"=>true}
```

- This example checks the status of the request using country_code and phone_number:
```ruby
Authy::PhoneVerification.status(phone_number: '+12345678910', country_code: '1')
> {"message"=>"Phone Verification status.", "status"=>"pending", "seconds_to_expire"=>500, "success"=>true}
```