### PR TITLE
Move docs to twilio.com/docs/authy/api; rewrite and standardize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,13 @@ Rails users can put this in config/initializers and create a new file called `au
 [Legacy (V1) documentation here.](verify-legacy-v1.md) **Verify V1 is not recommended for new development. Please consider using [Verify V2](https://www.twilio.com/docs/verify/api)**.
 
 ## Contributing
-
-Install development dependencies with pip:
-
-    sudo pip install -r requirements.txt
-
-To run tests:
-
-    make test
-or
-
-    make testfile tests/<test_case_file>
+* Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
+* Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.
+* Fork the project.
+* Start a feature/bugfix branch.
+* Commit and push until you are happy with your contribution.
+* Add tests.
+* Please try not to mess with the Rakefile, version, or history. If you want to have your own version, or is otherwise necessary, that is fine, but please isolate to its own commit.
 
 ## Copyright
 

--- a/verify-legacy-v1.md
+++ b/verify-legacy-v1.md
@@ -1,0 +1,35 @@
+# Phone Verification V1
+
+[Version 2 of the Verify API is now available!](https://www.twilio.com/docs/verify/api) V2 has an improved developer experience and new features. Some of the features of the V2 API include:
+
+* Twilio helper libraries in JavaScript, Java, C#, Python, Ruby, and PHP
+* PSD2 Secure Customer Authentication Support
+* Improved Visibility and Insights
+
+You are currently viewing Version 1. V1 of the API will be maintained for the time being, but any new features and development will be on Version 2. We strongly encourage you to do any new development with API V2. Check out the migration guide or the API Reference for more information.
+
+### API Reference
+
+API Reference is available at https://www.twilio.com/docs/verify/api/v1
+
+### Starting a phone verification
+
+`Authy::PhoneVerification.start` takes a country code, phone number and a method (sms or call) to deliver the code.
+
+```ruby
+response = Authy::PhoneVerification.start(via: "sms", country_code: 1, phone_number: "111-111-1111")
+if response.ok?
+  # verification was started
+end
+```
+
+### Checking a phone verification
+
+`Authy::PhoneVerification.check` takes a country code, phone number and a verification code.
+
+```ruby
+response = Authy::PhoneVerification.check(verification_code: "1234", country_code: 1, phone_number: "111-111-1111")
+if response.ok?
+  # verification was successful
+end
+```


### PR DESCRIPTION
Updates the README to be consistent with other Twilio supported helper libraries for Authy.

See:
https://www.twilio.com/docs/authy/api/applications
https://www.twilio.com/docs/authy/api/users
https://www.twilio.com/docs/authy/api/one-time-passwords
https://www.twilio.com/docs/authy/api/push-authentications

Also moves Verify V1 docs to a legacy readme and guides folks towards V2 of Verify

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
