### PR TITLE
Skip flaky test for now.

### DIFF
--- a/spec/authy/api_spec.rb
+++ b/spec/authy/api_spec.rb
@@ -228,6 +228,7 @@ describe "Authy::API" do
       end
 
       it "should be ok" do
+        skip("Flaky test. See: https://github.com/twilio/authy-ruby/issues/56")
         response = Authy::API.user_status(id: @user.id)
         expect(response.status).to be_kind_of(Hash)
         expect(response).to be_ok


### PR DESCRIPTION
Until we have an actual fix for #56 let's skip this test.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
